### PR TITLE
pa: Update camera package name

### DIFF
--- a/prebuilt/etc/default-permissions/pa-permissions.xml
+++ b/prebuilt/etc/default-permissions/pa-permissions.xml
@@ -26,7 +26,7 @@
 	</exception>
 	<!-- Paranoid Camera -->
 	<exception
-            package="org.codeaurora.snapcam">
+            package="co.paranoidandroid.camera">
 		<!-- Camera -->
 		<permission name="android.permission.CAMERA" fixed="false"/>
 		<!-- Microphone -->


### PR DESCRIPTION
We changed the package name of our camera, updating
pa-permissions with the change.

Change-Id: I2377be47bae773ccbd235a020c90addb1fd74539
Signed-off-by: Alex Naidis <alex.naidis@linux.com>